### PR TITLE
カメラにAlignment機能追加

### DIFF
--- a/objects/battle_board/Draw_0.gml
+++ b/objects/battle_board/Draw_0.gml
@@ -21,9 +21,21 @@ surface_set_target(_surface)
 	draw_clear_alpha(color_bg,0);
 surface_reset_target();
 
-surface_set_target(_surface)
-draw_surface_ext(application_surface,camera.x+camera._shake_pos_x,camera.y+camera._shake_pos_y,1/camera.scale_x,1/camera.scale_y,0,c_white,1-alpha_bg);
+surface_set_target(_surface);
+
+// カメラの位置から背景を描画する座標を求める
+var view_transform = camera.calculate_view_transform();
+var appsurf_x, appsurf_y, appsurf_angle;
+appsurf_angle = -view_transform[$"angle"];
+appsurf_x = view_transform[$"top_left_x"] + view_transform[$"size_x"] / 2;
+appsurf_y = view_transform[$"top_left_y"] + view_transform[$"size_y"] / 2;
+appsurf_x += lengthdir_x(view_transform[$"size_x"] / 2, appsurf_angle + 180) + lengthdir_x(view_transform[$"size_y"] / 2, appsurf_angle + 90)
+appsurf_y += lengthdir_y(view_transform[$"size_x"] / 2, appsurf_angle + 180) + lengthdir_y(view_transform[$"size_y"] / 2, appsurf_angle + 90)
+
+// _surfaceに背景を描画する
+draw_surface_ext(application_surface,appsurf_x+camera._shake_pos_x,appsurf_y+camera._shake_pos_y,1/camera.scale_x,1/camera.scale_y,appsurf_angle,c_white,1-alpha_bg);
 draw_surface(_surface4,0,0);
+
 surface_reset_target();
 
 

--- a/objects/camera/Other_10.gml
+++ b/objects/camera/Other_10.gml
@@ -6,6 +6,9 @@ height=480;
 scale_x=1;
 scale_y=1;
 angle=0;
+halign=fa_left;
+valign=fa_top;
+is_aligned_position_zero=true; // halign, valignで指定した基準点を(0, 0)とするか
 target=noone;
 
 shake_x=0;
@@ -23,8 +26,105 @@ _shake_time_y=0;
 _shake_positive_x=true;
 _shake_positive_y=true;
 
-use_room_limit=true;
+enable_limit=true; // カメラの移動範囲を制限するか
+use_room_limit=true; // ルームのサイズをカメラの移動範囲として参照するか
 limit_top=0;
 limit_bottom=0;
 limit_left=0;
 limit_right=0;
+is_target_always_center=true; // targetが設定されている場合、自動的にalignを中心にするか
+
+// カメラビューの位置を求める
+calculate_view_transform=function(){
+	var topLeftX,topLeftY;
+	topLeftX=x;
+	topLeftY=y;
+	var sizeX=width/scale_x;
+	var sizeY=height/scale_y;
+	var isTargetExists=instance_exists(target);
+
+	// is_target_always_centerがtrueの場合、基準点を中心とする
+	var hAlign,vAlign;
+	if(isTargetExists and is_target_always_center){
+		hAlign=fa_center;
+		vAlign=fa_middle;
+	}else{
+		hAlign=halign;
+		vAlign=valign;
+	}
+
+	var offsetFactorX,offsetFactorY;
+	switch (hAlign){
+		case fa_left:
+		offsetFactorX=0;
+		break;
+		case fa_center:
+		offsetFactorX=0.5;
+		break;
+		case fa_right:
+		offsetFactorX=1;
+		break;
+	}
+	switch (vAlign){
+		case fa_top:
+		offsetFactorY=0;
+		break;
+		case fa_middle:
+		offsetFactorY=0.5;
+		break;
+		case fa_bottom:
+		offsetFactorY=1;
+		break;
+	}
+	
+	// userX, userYに実際の座標を代入する
+	var userX,userY;
+	if(isTargetExists){
+		userX=target.x;
+		userY=target.y;
+	}else{
+		userX=x;
+		userY=y;
+		// is_aligned_position_zeroが0の場合、userX, userYを基準点へとズラす
+		if(is_aligned_position_zero){
+			userX+=width*offsetFactorX;
+			userY+=height*offsetFactorY;
+		}
+	}
+	
+	// カメラの視野の端の座標を求める
+	var leftEdgeX,rightEdgeX,topEdgeY,bottomEdgeY;
+	leftEdgeX=userX-sizeX*offsetFactorX;
+	rightEdgeX=userX+sizeX*(1-offsetFactorX);
+	topEdgeY=userY-sizeY*offsetFactorY;
+	bottomEdgeY=userY+sizeY*(1-offsetFactorY);
+	
+	// enable_limitがtrueの場合、カメラを可動範囲に合わせて調整する
+	if(isTargetExists and enable_limit){
+		var top=limit_top;
+		var bottom=limit_bottom;
+		var left=limit_left;
+		var right=limit_right;
+		if(use_room_limit){
+			top=0;
+			left=0;
+			right=room_width;
+			bottom=room_height;
+		}
+		if(right<rightEdgeX) leftEdgeX=right-sizeX;
+		if(leftEdgeX<left) leftEdgeX=left;
+		if(bottom<bottomEdgeY) topEdgeY=bottom-sizeY;
+		if(topEdgeY<top) topEdgeY=top;
+		
+	}
+	
+	topLeftX=leftEdgeX;
+	topLeftY=topEdgeY;
+	return {
+		"top_left_x": topLeftX,
+		"top_left_y": topLeftY,
+		"angle": angle,
+		"size_x": sizeX,
+		"size_y": sizeY
+	}
+};

--- a/objects/camera/Step_0.gml
+++ b/objects/camera/Step_0.gml
@@ -51,30 +51,8 @@ if(shake_y>0){
 	_shake_positive_y=true;
 }
 
-var sizeX=width/scale_x;
-var sizeY=height/scale_y;
-if(instance_exists(target)){
-	var top=limit_top;
-	var bottom=limit_bottom;
-	var left=limit_left;
-	var right=limit_right;
-	if(use_room_limit){
-		top=0;
-		left=0;
-		right=room_width;
-		bottom=room_height;
-	}
-	// Here x y are the center camera pos
-	x=target.x;
-	y=target.y;
-	if(x+sizeX/2>right) x=right-sizeX/2;
-	if(x-sizeX/2<left) x=left+sizeX/2;
-	if(y+sizeY/2>bottom) y=bottom-sizeY/2;
-	if(y-sizeY/2<top) y=top+sizeY/2;
-	// To top left camera pos
-	x-=sizeX/2;
-	y-=sizeY/2;
-}
-camera_set_view_pos(_camera,x+_shake_pos_x,y+_shake_pos_y);
-camera_set_view_size(_camera,sizeX,sizeY);
-camera_set_view_angle(_camera,angle);
+// カメラビューを設定する
+var viewTransform=calculate_view_transform();
+camera_set_view_pos(_camera,viewTransform[$"top_left_x"]+_shake_pos_x,viewTransform[$"top_left_y"]+_shake_pos_y);
+camera_set_view_size(_camera,viewTransform[$"size_x"],viewTransform[$"size_y"]);
+camera_set_view_angle(_camera,viewTransform[$"angle"]);


### PR DESCRIPTION
### カメラに移動や拡大などの基準点を変更する機能を追加します
- 以下のコードは`camera`の基準点を中心にします。
```
camera.halign = fa_center
camera.valign = fa_middle
```
- 上記のコードを実行した上で`camera.is_aligned_position_zero`を`false`に変更すると、`camera`の座標が(0, 0)のときroomの左上を画面中央に写します。
- `enable_limit`を`false`に変更すると、`target`が設定されていても`camera`の可動範囲を制限しないようになります。

### 枠の背景が透過されているとき、カメラを回転させた際の予期しない描画結果を修正します